### PR TITLE
feat: accumulated focus time tracking and AccumulatedBar UI (#8)

### DIFF
--- a/__tests__/integration/accumulated-bar-ui.test.tsx
+++ b/__tests__/integration/accumulated-bar-ui.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { AccumulatedBar } from '@/components/AccumulatedBar';
+
+describe('AccumulatedBar', () => {
+    it('renders the accumulated focus label and time string', () => {
+        render(<AccumulatedBar minutes={45} threshold={100} />);
+        expect(screen.getByText('Accumulated Focus')).toBeInTheDocument();
+        expect(screen.getByText('45m / 1h 40m')).toBeInTheDocument();
+    });
+
+    it('does not show the completion message when below threshold', () => {
+        render(<AccumulatedBar minutes={50} threshold={100} />);
+        expect(screen.queryByText(/Time for a meaningful break/)).not.toBeInTheDocument();
+    });
+
+    it('shows the completion message when at threshold', () => {
+        render(<AccumulatedBar minutes={100} threshold={100} />);
+        expect(screen.getByText(/Time for a meaningful break/)).toBeInTheDocument();
+    });
+
+    it('shows the completion message when above threshold', () => {
+        render(<AccumulatedBar minutes={120} threshold={100} />);
+        expect(screen.getByText(/Time for a meaningful break/)).toBeInTheDocument();
+    });
+
+    it('renders correctly at 0 minutes', () => {
+        render(<AccumulatedBar minutes={0} threshold={100} />);
+        expect(screen.getByText('0m / 1h 40m')).toBeInTheDocument();
+        expect(screen.queryByText(/Time for a meaningful break/)).not.toBeInTheDocument();
+    });
+
+    it('formats hours correctly', () => {
+        render(<AccumulatedBar minutes={75} threshold={100} />);
+        expect(screen.getByText('1h 15m / 1h 40m')).toBeInTheDocument();
+    });
+});

--- a/__tests__/integration/accumulated.test.ts
+++ b/__tests__/integration/accumulated.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import request from 'supertest';
+import { getTestServer } from './server';
+import { Server } from 'http';
+import mongoose from 'mongoose';
+
+describe('GET /api/v1/accumulated', () => {
+    let server: Server;
+    let token: string;
+    let userId: string;
+
+    beforeAll(async () => {
+        server = await getTestServer();
+
+        // Register + login a test user
+        await request(server).post('/api/v1/auth/register').send({
+            email: 'acc-test@example.com',
+            password: 'Password123!',
+            name: 'Acc Tester',
+        });
+
+        const loginRes = await request(server).post('/api/v1/auth/login').send({
+            email: 'acc-test@example.com',
+            password: 'Password123!',
+        });
+
+        const setCookie = loginRes.headers['set-cookie'];
+        token = Array.isArray(setCookie) ? setCookie[0] : String(setCookie);
+
+        // Get userId from /auth/me
+        const meRes = await request(server).get('/api/v1/auth/me').set('Cookie', token);
+        userId = meRes.body.data.id;
+    });
+
+    afterAll(async () => {
+        // Clean up sessions and user
+        if (userId) {
+            await mongoose.connection.collection('sessions').deleteMany({
+                userId: new mongoose.Types.ObjectId(userId),
+            });
+            await mongoose.connection.collection('users').deleteOne({
+                _id: new mongoose.Types.ObjectId(userId),
+            });
+        }
+        server.close();
+    });
+
+    afterEach(async () => {
+        // Clean up sessions between tests
+        if (userId) {
+            await mongoose.connection.collection('sessions').deleteMany({
+                userId: new mongoose.Types.ObjectId(userId),
+            });
+        }
+    });
+
+    it('returns 401 for unauthenticated request', async () => {
+        const res = await request(server).get('/api/v1/accumulated');
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 0 minutes when no focus sessions today', async () => {
+        const res = await request(server)
+            .get('/api/v1/accumulated')
+            .set('Cookie', token);
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.minutes).toBe(0);
+    });
+
+    it('returns correct sum of today\'s focus session durations', async () => {
+        // POST two focus sessions: 2700s (45 min) + 1800s (30 min) = 75 min
+        await request(server)
+            .post('/api/v1/sessions')
+            .set('Cookie', token)
+            .send({ duration: 2700, mode: 'focus', tag: 'Coding' });
+
+        await request(server)
+            .post('/api/v1/sessions')
+            .set('Cookie', token)
+            .send({ duration: 1800, mode: 'focus', tag: 'Writing' });
+
+        const res = await request(server)
+            .get('/api/v1/accumulated')
+            .set('Cookie', token);
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.minutes).toBe(75);
+    });
+
+    it('does not count break sessions toward accumulated total', async () => {
+        // POST a focus session + a break session
+        await request(server)
+            .post('/api/v1/sessions')
+            .set('Cookie', token)
+            .send({ duration: 2700, mode: 'focus' });
+
+        await request(server)
+            .post('/api/v1/sessions')
+            .set('Cookie', token)
+            .send({ duration: 600, mode: 'shortBreak' });
+
+        const res = await request(server)
+            .get('/api/v1/accumulated')
+            .set('Cookie', token);
+
+        expect(res.status).toBe(200);
+        // Only the focus session (45 min) should be counted
+        expect(res.body.data.minutes).toBe(45);
+    });
+});

--- a/src/components/AccumulatedBar.tsx
+++ b/src/components/AccumulatedBar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+interface AccumulatedBarProps {
+    minutes: number;
+    threshold: number;
+}
+
+const fmtDuration = (totalMinutes: number): string => {
+    const h = Math.floor(totalMinutes / 60);
+    const m = totalMinutes % 60;
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+};
+
+export function AccumulatedBar({ minutes, threshold }: AccumulatedBarProps) {
+    const pct = Math.min((minutes / Math.max(threshold, 1)) * 100, 100);
+    const segments = Math.floor(threshold / 25);
+    const isComplete = pct >= 100;
+
+    return (
+        <div style={{ width: '100%', maxWidth: 360 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                <span style={{
+                    fontFamily: 'var(--mono)', fontSize: 11,
+                    color: 'var(--text-dim)', letterSpacing: '0.12em', textTransform: 'uppercase',
+                }}>
+                    Accumulated Focus
+                </span>
+                <span style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--amber)' }}>
+                    {fmtDuration(minutes)} / {fmtDuration(threshold)}
+                </span>
+            </div>
+
+            {/* bar track */}
+            <div style={{
+                position: 'relative', height: 6,
+                background: 'var(--surface)', borderRadius: 3, overflow: 'hidden',
+            }}>
+                {/* fill */}
+                <div style={{
+                    position: 'absolute', left: 0, top: 0, height: '100%',
+                    width: `${pct}%`,
+                    background: isComplete
+                        ? 'var(--green)'
+                        : 'linear-gradient(90deg, var(--amber-dim), var(--amber))',
+                    borderRadius: 3,
+                    transition: 'width 1s ease',
+                    boxShadow: pct > 0 ? '0 0 8px var(--amber-glow)' : 'none',
+                }} />
+
+                {/* segment markers (every 25 min) */}
+                {segments > 1 && Array.from({ length: segments - 1 }).map((_, i) => (
+                    <div key={i} style={{
+                        position: 'absolute', top: 0, bottom: 0,
+                        left: `${((i + 1) / segments) * 100}%`,
+                        width: 1, background: 'var(--bg2)',
+                    }} />
+                ))}
+            </div>
+
+            {isComplete && (
+                <p style={{
+                    marginTop: 6, fontFamily: 'var(--sans)', fontSize: 11,
+                    color: 'var(--green)', letterSpacing: '0.08em',
+                }}>
+                    ✦ Time for a meaningful break
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/TimerWidget.tsx
+++ b/src/components/TimerWidget.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTimer, TimerSettings, TimerMode } from '@/hooks/useTimer';
 import { CircularTimer } from '@/components/CircularTimer';
+import { AccumulatedBar } from '@/components/AccumulatedBar';
 
 const fmt = (s: number) => {
     const m = Math.floor(s / 60).toString().padStart(2, '0');
@@ -32,7 +33,14 @@ export function TimerWidget() {
     const [accMinutes, setAccMinutes] = useState(0);
     const [notification, setNotification] = useState<string | null>(null);
 
-    // Fetch user and tags on mount
+    const fetchAccumulated = () => {
+        fetch('/api/v1/accumulated')
+            .then(res => { if (res.ok) return res.json(); return null; })
+            .then(data => { if (data?.data?.minutes !== undefined) setAccMinutes(data.data.minutes); })
+            .catch(err => console.error('Failed to fetch accumulated:', err));
+    };
+
+    // Fetch user, tags, and accumulated on mount
     useEffect(() => {
         fetch('/api/v1/auth/me')
             .then(res => {
@@ -40,7 +48,10 @@ export function TimerWidget() {
                 return null;
             })
             .then(data => {
-                if (data && data.data) setUser(data.data);
+                if (data && data.data) {
+                    setUser(data.data);
+                    fetchAccumulated(); // only makes sense if logged in
+                }
             })
             .catch(err => console.error('Failed to get user:', err));
 
@@ -80,10 +91,9 @@ export function TimerWidget() {
 
     const handleSessionEnd = (completedMode: TimerMode) => {
         if (completedMode === 'focus') {
-            setAccMinutes(prev => prev + settings.workMinutes);
             notify('Session complete. Take a break when you are ready.');
 
-            // Persist the focus session
+            // Persist the focus session, then refresh accumulated total from server
             fetch('/api/v1/sessions', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -92,7 +102,9 @@ export function TimerWidget() {
                     mode: 'focus',
                     tag: sessionTag
                 })
-            }).catch(err => console.error('Failed to save session:', err));
+            })
+                .then(() => fetchAccumulated())
+                .catch(err => console.error('Failed to save session:', err));
 
         } else {
             notify('Break over. Ready to focus?');
@@ -275,6 +287,13 @@ export function TimerWidget() {
                     {mode === 'focus' ? 'BREAK' : 'FOCUS'}
                 </button>
             </div>
+
+            {/* Accumulated focus bar — only shown when logged in */}
+            {user && (
+                <div className="w-full max-w-[360px]">
+                    <AccumulatedBar minutes={accMinutes} threshold={settings.accThreshold} />
+                </div>
+            )}
 
             {/* Tag autocomplete input */}
             {mode === 'focus' && (

--- a/src/pages/api/v1/accumulated.ts
+++ b/src/pages/api/v1/accumulated.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import mongoose from 'mongoose';
+import dbConnect from '@/lib/db';
+import Session from '@/lib/models/Session';
+import { verifyJWT } from '@/lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'GET') {
+        return res.status(405).json({ error: { code: 405, message: 'Method not allowed' } });
+    }
+
+    const token = req.cookies?.token;
+    if (!token) {
+        return res.status(401).json({ error: { code: 401, message: 'Not authenticated' } });
+    }
+
+    const payload = verifyJWT(token) as { sub?: string } | null;
+    if (!payload?.sub) {
+        return res.status(401).json({ error: { code: 401, message: 'Invalid token' } });
+    }
+
+    await dbConnect();
+
+    // Start of today in UTC
+    const startOfDay = new Date();
+    startOfDay.setUTCHours(0, 0, 0, 0);
+
+    const result = await Session.aggregate([
+        {
+            $match: {
+                userId: new mongoose.Types.ObjectId(payload.sub),
+                mode: 'focus',
+                createdAt: { $gte: startOfDay },
+            },
+        },
+        {
+            $group: {
+                _id: null,
+                totalSeconds: { $sum: '$duration' },
+            },
+        },
+    ]);
+
+    const totalSeconds = result[0]?.totalSeconds ?? 0;
+    const minutes = Math.round(totalSeconds / 60);
+
+    return res.status(200).json({
+        data: { minutes },
+    });
+}


### PR DESCRIPTION
## Summary

Closes #8

Implements server-side accumulated focus time tracking and the `AccumulatedBar` UI component from prototype v2.

## Changes

### Backend
- **`GET /api/v1/accumulated`** — MongoDB aggregation pipeline that sums today's `focus` session durations for the authenticated user. Returns `{ data: { minutes: number } }`.

### Frontend
- **`AccumulatedBar.tsx`** — Segmented amber progress bar matching prototype v2 (lines 188–227). Turns green + shows "✦ Time for a meaningful break" when `minutes >= threshold`.
- **`TimerWidget.tsx`** — Replaced local `accMinutes` counter with server fetch on mount and after each session completes.

## How to Test Manually

> **Requires**: being logged in. Grab your `token` cookie from DevTools → Application → Cookies.

**Seed sample sessions via curl** (3 focus sessions = 100 min → triggers threshold):

```bash
TOKEN="<your token>"

curl -s -X POST http://localhost:3000/api/v1/sessions \
  -H "Content-Type: application/json" -H "Cookie: token=$TOKEN" \
  -d '{"duration": 2700, "mode": "focus", "tag": "Coding"}'

curl -s -X POST http://localhost:3000/api/v1/sessions \
  -H "Content-Type: application/json" -H "Cookie: token=$TOKEN" \
  -d '{"duration": 1800, "mode": "focus", "tag": "PR Reviews"}'

curl -s -X POST http://localhost:3000/api/v1/sessions \
  -H "Content-Type: application/json" -H "Cookie: token=$TOKEN" \
  -d '{"duration": 1500, "mode": "focus", "tag": "Writing"}'
```

Then **refresh** — the `AccumulatedBar` below the timer controls should show **green** with "✦ Time for a meaningful break".

To test a **real session end**: open Settings → set Work Duration to **1 min** → let it count to zero → bar updates automatically.

> **Note**: Sessions only save on timer **completion** (not on pause/reset). This is intentional — partial sessions don't get logged.

## Tests

```
Test Files  2 passed (2)
     Tests  10 passed (10)
```

- `accumulated.test.ts` — API: 401 unauth, 0 minutes empty, correct sum, breaks excluded
- `accumulated-bar-ui.test.tsx` — Component: label, time format, below/at/above threshold states
