### PR TITLE
fix: reset accumulated focus after long break so short breaks remain available

### DIFF
--- a/src/components/TimerWidget.tsx
+++ b/src/components/TimerWidget.tsx
@@ -109,6 +109,11 @@ export function TimerWidget() {
         } else {
             notify('Break over. Ready to focus?');
 
+            // After a long break, reset accumulated so short breaks are available again
+            if (completedMode === 'longBreak') {
+                setAccMinutes(0);
+            }
+
             // Persist the break session
             const duration = completedMode === 'shortBreak'
                 ? settings.shortBreakMinutes * 60


### PR DESCRIPTION
After completing a long break, accMinutes resets to 0, allowing the user to take short breaks in the next focus cycle instead of being locked into long breaks for the rest of the day.

Refs #8