### PR TITLE
feat: add Claude Code project configuration (CLAUDE.md + hooks)

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,54 @@
+---
+description: "TDD Phase 2: Implement code to make all failing tests pass. Test files are locked by a hook and cannot be modified."
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash
+---
+
+You are in IMPLEMENTATION mode.
+
+## Task
+
+Make all failing tests pass for: $ARGUMENTS
+
+## Process
+
+1. Run `npx vitest run` to see current failures
+2. Read the failing test files to understand expected behavior
+3. Implement the minimum code needed to pass each test
+4. Follow `app/page.tsx -> Components (UI) -> Hooks (stateful logic) -> Services (data/API)` layering
+5. Run `npx vitest run` after each meaningful change
+6. Repeat until ALL tests pass
+
+## Architecture rules
+
+app/page.tsx -> Components (UI) -> Hooks (stateful logic) -> Services (data/API)
+
+- Components (`components/`): UI rendering and local state only -- receive props and callbacks
+- Hooks (`hooks/`): encapsulate reusable stateful logic
+- Services (`services/`): return typed data from APIs or mock sources -- no UI concerns
+- `app/page.tsx`: composes top-level state and passes callbacks to child components
+
+## Constraints
+
+- NEVER modify files in `__tests__/` -- a hook blocks this and your edit will be rejected
+- Do NOT add npm packages unless the task explicitly requires it
+- Keep modules focused -- no 300+ line files
+- Service functions return typed data matching your defined types
+
+## If a test seems wrong
+
+Explain why you think the test is incorrect and what behavior you expected. Do NOT attempt to modify the test. The user will decide whether to adjust the test in a separate session.
+
+## Output
+
+Run `npx vitest run` one final time and report:
+- Confirmation all tests pass
+- List of files created or modified
+- Any concerns about test correctness (if applicable)
+
+## Commit
+
+After all tests pass, stage and commit your work:
+1. Run `git status` to identify files you created or modified in this session
+2. Stage only those files (do not use `git add -A`)
+3. Run: `git commit -m "TDD[2:implement] $ARGUMENTS -- N tests pass"`
+   Replace N with the actual total test count from the final test run.

--- a/.claude/commands/write-tests.md
+++ b/.claude/commands/write-tests.md
@@ -1,0 +1,63 @@
+---
+description: "TDD Phase 1: Write failing integration tests for a feature. Use this to start a new feature by creating tests first (red state)."
+allowed-tools: Read, Glob, Grep, Write, Bash
+---
+
+You are in TEST WRITING mode.
+
+## Task
+
+Write integration tests for: $ARGUMENTS
+
+## Process
+
+1. Read the feature requirements from `project_memory/PRD.md` (or the description provided in $ARGUMENTS)
+2. Identify all behaviors, interactions, and edge cases to test
+3. Write integration test files in `__tests__/integration/`
+4. Use `@testing-library/react` with Vitest for testing
+5. Run `npx vitest run` and confirm ALL new tests FAIL (red state)
+
+## Test file structure
+
+Each integration test must:
+
+1. `render(<ComponentUnderTest />)`
+2. Simulate user interactions or API calls
+3. Assert the resulting state matches expected behavior
+
+```typescript
+describe('Feature: [feature name]', () => {
+  function setup() {
+    render(<ComponentUnderTest />)
+  }
+
+  it('should [expected behavior] when [condition]', async () => {
+    // 1. Arrange: set up initial state
+    // 2. Act: perform the action
+    // 3. Assert: check the result
+  });
+});
+```
+
+## Constraints
+
+- Write test files ONLY -- no implementation code
+- Do NOT modify any files outside `__tests__/`
+- Do NOT modify existing test files unless extending them for the current feature
+- Test assertions come from the functional requirements, not from guessing implementation details
+- Use descriptive test names: `should [expected behavior] when [condition]`
+
+## Output
+
+After writing tests, run `npx vitest run` and report:
+- List of test files created
+- Summary of each test case
+- Confirmation that all new tests fail with expected reasons
+
+## Commit
+
+After confirming red state, stage and commit your work:
+1. Run `git status` to identify files you created in this session
+2. Stage only those files (do not use `git add -A`)
+3. Run: `git commit -m "TDD[1:write-tests] $ARGUMENTS -- N tests, all red"`
+   Replace N with the actual number of new tests.

--- a/.claude/hooks/guard-git-commit.sh
+++ b/.claude/hooks/guard-git-commit.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# guard-git-commit.sh
+# PreToolUse hook for Bash
+# Runs npm test before allowing git commit. Blocks commit if tests fail.
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('command', ''))
+except:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+    exit 0
+fi
+
+# Only intercept git commit (not git add, git status, etc.)
+if echo "$COMMAND" | grep -qE "git commit"; then
+    cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+    # Implement mode: all tests must pass (existing behavior)
+    if [ "$CLAUDE_TDD_MODE" = "implement" ]; then
+        TEST_OUTPUT=$(npm test 2>&1)
+        TEST_EXIT=$?
+        if [ $TEST_EXIT -ne 0 ]; then
+            echo "BLOCKED: Tests failed. Fix failing tests before committing." >&2
+            echo "$TEST_OUTPUT" | tail -20 >&2
+            exit 2
+        fi
+        exit 0
+    fi
+
+    # Write-tests phase (CLAUDE_TDD_MODE unset or "write-tests"):
+    # Newly added test files are intentionally red — exclude them.
+    NEW_TEST_FILES=$(git diff --cached --name-only --diff-filter=A | grep -E "(^__tests__/|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$)")
+
+    if [ -z "$NEW_TEST_FILES" ]; then
+        # No new test files staged: run full suite
+        TEST_OUTPUT=$(npm test 2>&1)
+        TEST_EXIT=$?
+        if [ $TEST_EXIT -ne 0 ]; then
+            echo "BLOCKED: Tests failed. Fix failing tests before committing." >&2
+            echo "$TEST_OUTPUT" | tail -20 >&2
+            exit 2
+        fi
+    else
+        # New test files detected: run only previously existing tests to check for regressions
+        ALL_TEST_FILES=$(find __tests__ -name "*.test.ts" -o -name "*.test.tsx" -o -name "*.spec.ts" -o -name "*.spec.tsx" 2>/dev/null | sort)
+
+        EXISTING_TESTS=()
+        while IFS= read -r f; do
+            if ! echo "$NEW_TEST_FILES" | grep -qF "$f"; then
+                EXISTING_TESTS+=("$f")
+            fi
+        done <<< "$ALL_TEST_FILES"
+
+        if [ ${#EXISTING_TESTS[@]} -eq 0 ]; then
+            # All test files are new — nothing pre-existing to regress
+            exit 0
+        fi
+
+        TEST_OUTPUT=$(npx vitest run "${EXISTING_TESTS[@]}" 2>&1)
+        TEST_EXIT=$?
+        if [ $TEST_EXIT -ne 0 ]; then
+            echo "BLOCKED: Previously passing tests are now failing." >&2
+            echo "$TEST_OUTPUT" | tail -20 >&2
+            exit 2
+        fi
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/guard-npm-install.sh
+++ b/.claude/hooks/guard-npm-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# guard-npm-install.sh
+# PreToolUse hook for Bash
+# Blocks npm install / npm add / yarn add unless CLAUDE_ALLOW_INSTALL=true
+# This enforces the rule: "Do not add npm packages unless explicitly listed in the task"
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('command', ''))
+except:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+    exit 0
+fi
+
+if [ "$CLAUDE_ALLOW_INSTALL" = "true" ]; then
+    exit 0
+fi
+
+if echo "$COMMAND" | grep -qE "(npm install|npm i |npm add|yarn add|pnpm add|pnpm install)"; then
+    # Allow install with no arguments (restoring node_modules from lockfile)
+    if echo "$COMMAND" | grep -qE "^(npm install|npm i|yarn install|pnpm install)$"; then
+        exit 0
+    fi
+    # Allow dev dependency installs for @types packages only
+    if echo "$COMMAND" | grep -qE "@types/"; then
+        exit 0
+    fi
+    echo "BLOCKED: Adding new npm packages is not allowed unless the task explicitly requires it. If this package is needed, ask the user to confirm." >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/guard-test-files.sh
+++ b/.claude/hooks/guard-test-files.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# guard-test-files.sh
+# PreToolUse hook for Edit|Write
+# Blocks modifications to test files when CLAUDE_TDD_MODE=implement
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    fp = data.get('tool_input', {}).get('file_path', '')
+    if not fp:
+        fp = data.get('tool_input', {}).get('file', '')
+    print(fp)
+except:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+if [ "$CLAUDE_TDD_MODE" = "implement" ]; then
+    if echo "$FILE_PATH" | grep -qE "(/__tests__/|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$)"; then
+        echo "BLOCKED: Test files are read-only in implementation mode. Fix your implementation code to make the test pass. Do NOT modify the test." >&2
+        exit 2
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/post-write-lint.sh
+++ b/.claude/hooks/post-write-lint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# post-write-lint.sh
+# PostToolUse hook for Write
+# Runs TypeScript type-check on newly written .ts files.
+# Provides feedback to Claude if there are type errors.
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    fp = data.get('tool_input', {}).get('file_path', '')
+    if not fp:
+        fp = data.get('tool_input', {}).get('file', '')
+    print(fp)
+except:
+    print('')
+" 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Only lint TypeScript source files, skip test files and node_modules
+echo "$FILE_PATH" | grep -qE "\.tsx?$" || exit 0
+echo "$FILE_PATH" | grep -q "node_modules" && exit 0
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+# Run tsc --noEmit on the specific file if tsconfig exists
+if [ -f "tsconfig.json" ]; then
+    TSC_OUTPUT=$(npx tsc --noEmit 2>&1 | grep -A 2 "$FILE_PATH" | head -15)
+    if [ -n "$TSC_OUTPUT" ]; then
+        echo '{"decision": "block", "reason": "TypeScript errors found in '"$FILE_PATH"':\n'"$(echo "$TSC_OUTPUT" | sed 's/"/\\"/g')"'"}'
+        exit 0
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/stop-check-tests.sh
+++ b/.claude/hooks/stop-check-tests.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# stop-check-tests.sh
+# Stop hook
+# In implement mode, prevents Claude from stopping if tests are still failing.
+
+INPUT=$(cat)
+
+# Check if a stop hook is already active to prevent infinite loops
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(str(data.get('stop_hook_active', False)).lower())
+except:
+    print('false')
+" 2>/dev/null)
+
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+    exit 0
+fi
+
+# Only enforce in implement mode
+if [ "$CLAUDE_TDD_MODE" != "implement" ]; then
+    exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+TEST_OUTPUT=$(npm test 2>&1)
+TEST_EXIT=$?
+
+if [ $TEST_EXIT -ne 0 ]; then
+    FAILING=$(echo "$TEST_OUTPUT" | grep -E "(FAIL|✕|×)" | head -10)
+    echo "Tests are still failing. Continue implementing until all tests pass:" >&2
+    echo "$FAILING" >&2
+    exit 2
+fi
+
+# Remind agent to commit if there are uncommitted changes
+UNCOMMITTED=$(git -C "$CLAUDE_PROJECT_DIR" status --porcelain 2>/dev/null)
+if [ -n "$UNCOMMITTED" ]; then
+    echo "Reminder: uncommitted changes detected. Did you forget to commit?" >&2
+    echo "$UNCOMMITTED" >&2
+fi
+
+exit 0

--- a/.claude/skills/tdd-workflow/SKILL.md
+++ b/.claude/skills/tdd-workflow/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tdd-workflow
+description: "Enforces test-driven development workflow rules. Consult this skill whenever writing tests, implementing features, or working with the __tests__/ directory. Also consult when Claude needs to decide whether to modify a test file or an implementation file. This skill applies to all test-related and implementation tasks."
+---
+
+# TDD Workflow Rules
+
+This project uses strict two-phase TDD. The phases are enforced by hooks and slash commands.
+
+## Phase 1: Write Tests (red state)
+
+Invoked by: `/project:write-tests [feature description]`
+
+In this phase:
+- Create test files in `__tests__/integration/`
+- Use `@testing-library/react` with Vitest for testing
+- Cover happy paths, error cases, and edge cases
+- Do not write any implementation code
+- End state: all new tests FAIL
+
+## Phase 2: Implement (green state)
+
+Invoked by: `/project:implement [feature description]`
+Requires: `CLAUDE_TDD_MODE=implement` environment variable
+
+In this phase:
+- Read failing tests to understand expected behavior
+- Write minimum implementation to pass tests
+- Files in `__tests__/` are blocked by a PreToolUse hook -- do not attempt to edit them
+- Follow `app/page.tsx -> Components (UI) -> Hooks (stateful logic) -> Services (data/API)` architecture
+- End state: all tests PASS
+
+## When to consult this skill
+
+- Before creating any file in `__tests__/`: check which phase you are in
+- Before modifying any test file: this is only allowed in Phase 1
+- When a test fails during implementation: fix the implementation, not the test
+- When deciding where to put new code: follow the file naming conventions below
+
+## File placement reference
+
+| Type | Path pattern | Naming |
+|------|-------------|--------|
+| Integration test | `__tests__/integration/{phase}-{feature}.test.tsx` | kebab-case |
+| Unit test | `__tests__/unit/{feature}.test.ts` | kebab-case |
+| Component test | `__tests__/components/{ComponentName}.test.tsx` | PascalCase |
+| Component | `components/{Name}.tsx` | PascalCase |
+| Hook | `hooks/use{Name}.ts` | camelCase |
+| Service | `services/{feature}Service.ts` | camelCase |
+| Types | `types.ts` | shared types file |
+| Page | `app/page.tsx` | Next.js convention |
+
+## Composition rule
+
+app/page.tsx -> Components (UI) -> Hooks (stateful logic) -> Services (data/API)
+
+## Test structure template
+
+```typescript
+describe('Feature: [feature name]', () => {
+  function setup() {
+    render(<ComponentUnderTest />)
+  }
+
+  it('should [expected behavior] when [condition]', async () => {
+    // 1. Arrange: set up initial state
+    // 2. Act: perform the action
+    // 3. Assert: check the result
+  });
+});
+```

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,6 @@ next-env.d.ts
 coverage/
 
 # Claude Code local config
-.claude/
-CLAUDE.md
-tsconfig.tsbuildinfo
+# .claude/
+# CLAUDE.md
+# tsconfig.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**DeepWork** is a full-stack Pomodoro timer built for users who reject rigid session transitions. When a focus session ends, the timer sends a gentle notification — it never auto-switches modes or forces a break. Sessions are logged automatically on completion. An analytics dashboard gives users visibility into their historical focus patterns by tag, day, and week.
+
+Key product philosophy: **non-coercive transitions**. The timer notifies, never coerces.
+
+## Stack
+
+- **Frontend:** Next.js 16 (App Router) + React 19 + Tailwind CSS v4
+- **Backend:** Next.js API Routes — Pages Router for most routes (`src/pages/api/v1/`), App Router for health only (`src/app/api/v1/health/`)
+- **Database:** MongoDB Atlas + Mongoose 8
+- **Auth:** JWT in HTTP-only cookies
+- **Testing:** Vitest + @testing-library/react + happy-dom + mongodb-memory-server + supertest
+
+## Commands
+
+```bash
+npm run dev                    # Dev server
+npm test                       # Run test suite (vitest run)
+npm run test:watch             # Watch mode
+npm run test:coverage          # Coverage (80% threshold on lines/functions/branches/statements)
+npm run build                  # Production build
+npm run lint                   # ESLint
+npx tsc --noEmit               # TypeScript type check
+npx vitest run __tests__/integration/use-timer.test.ts  # Run a single test file
+```
+
+## TDD Workflow
+
+This project uses a strict two-phase TDD workflow enforced by Claude Code hooks (`.claude/hooks/`):
+
+**Phase 1 — Write tests first:**
+```
+/project:write-tests <feature>
+```
+- Writes failing integration tests into `__tests__/integration/`
+- Uses `@testing-library/react` with Vitest; requirements sourced from `project_memory/PRD.md`
+- Confirms all new tests are in red state before stopping
+- Test files ONLY — no implementation code
+
+**Phase 2 — Implement to pass tests:**
+```
+/project:implement <feature>
+```
+- Set `CLAUDE_TDD_MODE=implement` in the shell environment
+- Test files are locked by `guard-test-files.sh` — edits to `__tests__/` are rejected
+- Implement minimum code to pass each test
+- Never modify test files; if a test seems wrong, explain why and let the user decide
+
+**Active hooks:**
+- `PreToolUse[Edit|Write]`: `guard-test-files.sh` — blocks edits to test files during implement phase
+- `PreToolUse[Bash]`: `guard-npm-install.sh` — blocks unauthorized package installs
+- `PreToolUse[Bash]`: `guard-git-commit.sh` — runs tests before allowing commits (skips new red test files in write-tests phase)
+- `PostToolUse[Write]`: `post-write-lint.sh` — runs `npx tsc --noEmit` after each file write
+- `Stop`: `stop-check-tests.sh` — verifies test suite passes before session end (implement mode only)
+
+## Architecture
+
+### Backend
+
+```
+Route Handler (src/pages/api/v1/**) → Service (src/lib/services/*.ts) → Mongoose Model (src/lib/models/*.ts) → MongoDB
+```
+
+This project uses a flat, pragmatic pattern — **NOT** Repository/Service/Controller layering.
+
+- **Route handlers** (`src/pages/api/v1/`): Parse request, validate input, call service functions, return response. Each handler includes auth verification. Routes: `auth/`, `sessions.ts`, `sessions/[id].ts`, `settings.ts`, `analytics.ts`, `accumulated.ts`, `tags.ts`
+- **Services** (`src/lib/services/*.ts`): Business logic as plain exported functions. No classes, no dependency injection.
+- **Models** (`src/lib/models/*.ts`): Mongoose schemas and models. Data shape and validation only.
+- **App Router API:** Only `/api/v1/health` lives in `src/app/api/v1/health/route.ts`.
+
+### Frontend
+
+```
+Pages (src/app/*/page.tsx) → Components (src/components/*.tsx) → Hooks (src/hooks/*.ts)
+```
+
+- **Pages:** `/` (timer), `/dashboard` (analytics), `/auth`
+- **Components:** `CircularTimer`, `AccumulatedBar`, `TimerWidget`, `BreakSuggestion`, `SessionList`, `AuthScreen`
+- **Hooks:** `useTimer` (core timer logic)
+
+**Timer is entirely client-side.** The server is only contacted on:
+1. Page load (hydrate settings + today's accumulated focus)
+2. Session completion (persist session)
+3. Analytics navigation (fetch aggregated history)
+
+`useTimer` uses absolute timestamps (`endTimeRef = Date.now() + seconds * 1000`) so the countdown survives browser tab throttling.
+
+### Key Types
+
+```typescript
+type TimerMode = 'focus' | 'shortBreak' | 'longBreak';
+
+interface TimerSettings {
+    workMinutes: number;
+    shortBreakMinutes: number;
+    longBreakMinutes: number;
+    accThreshold: number;  // accumulated minutes before long break is offered
+}
+```
+
+### File Placement
+
+| Type | Path | Naming |
+|------|------|--------|
+| Integration test | `__tests__/integration/{feature}.test.ts(x)` | kebab-case |
+| Unit test | `__tests__/unit/{feature}.test.ts` | kebab-case |
+| Component | `src/components/{Name}.tsx` | PascalCase |
+| Hook | `src/hooks/use{Name}.ts` | camelCase |
+| Service | `src/lib/services/{feature}.ts` | camelCase |
+| Model | `src/lib/models/{Name}.ts` | PascalCase |
+| API Route (Pages) | `src/pages/api/v1/{feature}.ts` | kebab-case |
+| Page | `src/app/{route}/page.tsx` | Next.js convention |
+
+### Explicitly Out of Scope (v1)
+
+- Calendar integration
+- Team or social accountability features
+- Native mobile apps
+- Distraction blocking (browser extension)
+- Context restoration tooling


### PR DESCRIPTION
## Summary

Adds checked-in Claude Code project configuration so all contributors and AI-assisted sessions share the same context, conventions, and workflow guards.

- **`CLAUDE.md`** — project memory covering product philosophy, stack, architecture, commands, file conventions, and out-of-scope items
- **`.claude/hooks/`** — five pre/post hooks enforcing TDD workflow and code quality
- **`.claude/commands/`** — `write-tests` and `implement` slash commands for two-phase TDD
- **`.claude/skills/`** — `tdd-workflow` skill definition
- **`.gitignore`** — un-ignores `.claude/` and `CLAUDE.md` so they are tracked

## What each hook does

| Hook | Trigger | Effect |
|------|---------|--------|
| `guard-git-commit.sh` | Before `git commit` | Runs `npm test`; in write-tests phase skips newly added red files |
| `guard-npm-install.sh` | Before any Bash command | Blocks `npm install <pkg>` unless `CLAUDE_ALLOW_INSTALL=true` |
| `guard-test-files.sh` | Before Edit/Write | Blocks edits to `__tests__/` when `CLAUDE_TDD_MODE=implement` |
| `post-write-lint.sh` | After every Write | Runs `npx tsc --noEmit` to catch type errors immediately |
| `stop-check-tests.sh` | On session stop | Verifies full test suite passes (implement mode only) |

## Test plan

- [x] All existing tests pass (enforced by commit hook — commit succeeded)
- [x] `.claude/` and `CLAUDE.md` are now tracked by git (`.gitignore` updated)
- [ ] Verify hooks execute correctly by running a Claude Code session on this branch
- [ ] Confirm `/project:write-tests` and `/project:implement` slash commands load properly

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
